### PR TITLE
마커 그리기 샘플의 마커가 지정한 위치보다 위에 찍히는 오류 수정

### DIFF
--- a/NMapSampleObjc/NMapSampleObjc/NMapViewResources.m
+++ b/NMapSampleObjc/NMapSampleObjc/NMapViewResources.m
@@ -36,7 +36,7 @@
         case NMapPOIflagTypeCompass:
             return CGPointMake(0.5, 0.5);
         case UserPOIflagTypeDefault:
-            return CGPointMake(0.5, 1.5);
+            return CGPointMake(0.5, 1.0);
         case UserPOIflagTypeInvisible:
             return CGPointMake(0.5, 0.5);
         default:


### PR DESCRIPTION
개발자 포럼에 문의로 올라온 이슈인데요.
샘플의 anchorPoint 가 잘못 지정되어 있어 수정했습니다.
사용자에게 잘못된 샘플을 제공한 것이라, 가급적 빨리 배포하는게 좋겠습니다.